### PR TITLE
feat: 맵에서 top5카페 하단에 띄우는 바 생성

### DIFF
--- a/src/components/feature/OnBoarding/UserPreferences.jsx
+++ b/src/components/feature/OnBoarding/UserPreferences.jsx
@@ -24,7 +24,7 @@ export default function UserPreferences() {
 
 const mapToApiData = (prefs) => {
   const purposeMap = { "공부": 0, "레포트 작성": 1, "팀플": 2, "회의": 3 };
-  const moodMap = { "calm": 0, "적당": 1, "lively": 2, "chill": 3, "RnB": 4, "LoFi": 5, "whichever": 6 };
+  const moodMap = { "calm": 0, "적당": 1, "chill": 2, "RnB": 3, "LoFi": 4, "whichever": 5};
   
   let facilityCode = -1;
   if (prefs.outlet && prefs.wifi) facilityCode = 2;

--- a/src/components/feature/map/CafeListItem.css
+++ b/src/components/feature/map/CafeListItem.css
@@ -1,0 +1,98 @@
+/* CafeListItem.css */
+.cafe-item-container {
+  display: flex;
+  padding: 15px;
+  border-bottom: 1px solid #f0f0f0;
+  background-color: white;
+  align-items: flex-start;
+}
+
+.cafe-image {
+  width: 80px;
+  height: 80px;
+  border-radius: 10px;
+  object-fit: cover;
+  margin-right: 15px;
+}
+
+.cafe-details {
+  flex-grow: 1;
+  display: flex;
+  flex-direction: column;
+}
+
+.cafe-info-header {
+  display: flex;
+  align-items: center;
+  margin-bottom: 5px;
+}
+
+.cafe-name {
+  font-size: 18px;
+  font-weight: bold;
+  margin-right: 8px;
+}
+
+.cafe-rating {
+  font-size: 14px;
+  color: #e6b823;
+}
+
+.cafe-status-line {
+  display: flex;
+  align-items: center;
+  font-size: 13px;
+  color: #888;
+  margin-bottom: 8px;
+}
+
+.operating-status {
+  font-weight: bold;
+  margin-right: 8px;
+}
+.operating-status.open { color: #3498db; }
+.operating-status.closed { color: #e74c3c; }
+
+.cafe-hashtags {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+}
+
+.hashtag {
+  background-color: #f2f2f2;
+  color: #555;
+  padding: 4px 8px;
+  border-radius: 15px;
+  font-size: 12px;
+}
+
+.cafe-actions {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: space-between;
+  height: 80px;
+  margin-left: 15px;
+}
+
+.congestion-dot {
+  width: 12px;
+  height: 12px;
+  border-radius: 50%;
+}
+.status-green { background-color: #2ecc71; }
+.status-orange { background-color: #f39c12; }
+.status-red { background-color: #e74c3c; }
+
+.directions-button {
+  background-color: #e6b823;
+  color: white;
+  border: none;
+  border-radius: 8px;
+  padding: 8px 12px;
+  font-size: 14px;
+  font-weight: bold;
+  cursor: pointer;
+  white-space: nowrap;
+}

--- a/src/components/feature/map/CafeListItem.jsx
+++ b/src/components/feature/map/CafeListItem.jsx
@@ -1,0 +1,47 @@
+import React from 'react';
+import './CafeListItem.css';
+
+// 혼잡도 텍스트와 색상을 매핑하는 객체
+const congestionStatus = {
+  green: { text: "여유", className: "status-green" },
+  orange: { text: "보통", className: "status-orange" },
+  red: { text: "혼잡", className: "status-red" },
+};
+
+export default function CafeListItem({ cafe }) {
+  // 별점을 별 아이콘으로 변환하는 간단한 함수
+  const renderStars = (rating) => {
+    const fullStars = Math.floor(rating);
+    const halfStar = rating % 1 >= 0.5;
+    let stars = '★'.repeat(fullStars);
+    if (halfStar) stars += '☆'; // 반쪽 별 대신 빈 별로 간단히 표현
+    return stars.padEnd(5, '☆');
+  };
+
+  return (
+    <div className="cafe-item-container">
+      <img src={cafe.imageUrl} alt={cafe.name} className="cafe-image" />
+      <div className="cafe-details">
+        <div className="cafe-info-header">
+          <span className="cafe-name">{cafe.name}</span>
+          <span className="cafe-rating">{renderStars(cafe.rating)}</span>
+        </div>
+        <div className="cafe-status-line">
+          <span className={`operating-status ${cafe.isOperating ? 'open' : 'closed'}`}>
+            {cafe.isOperating ? '영업중' : '영업종료'}
+          </span>
+          <span className="cafe-distance">{cafe.distance} | 도보 {cafe.walkingTime}분</span>
+        </div>
+        <div className="cafe-hashtags">
+          {cafe.hashtags.map(tag => (
+            <span key={tag} className="hashtag">{tag}</span>
+          ))}
+        </div>
+      </div>
+      <div className="cafe-actions">
+        <div className={`congestion-dot ${congestionStatus[cafe.congestion].className}`}></div>
+        <button className="directions-button">길찾기</button>
+      </div>
+    </div>
+  );
+}

--- a/src/components/feature/map/TopCafesSheet.css
+++ b/src/components/feature/map/TopCafesSheet.css
@@ -1,0 +1,81 @@
+/* TopCafesSheet.css */
+
+/* 'TopCafesSheet' 전체 컨테이너 */
+.sheet-container {
+  position: absolute;
+  left: 0; right: 0; bottom: 0;
+  background: #fff;
+  border-top-left-radius: 20px;
+  border-top-right-radius: 20px;
+  box-shadow: 0 -5px 20px rgba(0,0,0,.1);
+  transition: transform .35s ease-in-out;
+  transform: translateY(calc(100% - 120px)); /* 기본적으로 바 아래에 위치 */
+  z-index: 500;
+  display: flex;
+  flex-direction: column;
+  height: auto;  /* 높이를 자동으로 계산 */
+  max-height: 85vh;  /* 최대 높이를 85%로 설정 */
+  overflow: hidden; /* 내용이 넘칠 경우 스크롤을 적용 */
+}
+
+/* 'expanded' 클래스가 적용된 경우 바가 올라가면서 화면 표시 */
+.sheet-container.expanded {
+  transform: translateY(0); /* 바가 최상단으로 올라옴 */
+}
+
+/* 헤더 영역 */
+.sheet-header {
+  position: sticky;
+  top: 0;
+  background: #fff;
+  padding: 10px 20px 16px;
+  cursor: pointer;
+  flex-shrink: 0;
+  z-index: 2;
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);  /* 헤더와 내용 구분 */
+}
+
+/* 드래그 바 (grabber) */
+.grabber {
+  width: 40px;
+  height: 5px;
+  background: #d9d9d9;
+  border-radius: 4px;
+  margin: 0 auto 10px;
+}
+
+/* 헤더 내용 */
+.header-content {
+  display: flex;
+  flex-direction: column;
+  gap: 5px;
+}
+
+.header-content .current-time {
+  font-size: 12px;
+  color: #888;
+  margin-bottom: 5px;
+}
+
+.sheet-title {
+  font-size: 20px;
+  font-weight: 700;
+  margin: 0;
+}
+
+.sheet-title .nickname {
+  color: #e6b823;
+}
+
+/* 카페 리스트 영역 */
+.cafe-list {
+  flex: 1;
+  overflow-y: auto;
+  padding: 10px 20px;
+  padding-bottom: 20px;  /* 바닥 여백을 위한 패딩 */
+  -webkit-overflow-scrolling: touch; /* 아이폰 하단 안전 영역 여백 */
+}
+
+.cafe-list::-webkit-scrollbar {
+  display: none;  /* 스크롤바 숨기기 */
+}

--- a/src/components/feature/map/TopCafesSheet.jsx
+++ b/src/components/feature/map/TopCafesSheet.jsx
@@ -1,0 +1,47 @@
+import React, { useState, useEffect } from 'react';
+import './TopCafesSheet.css';
+import { topCafes } from '../../../mocks/cafe-data';
+import CafeListItem from './CafeListItem';
+
+export default function TopCafesSheet() {
+  const [isExpanded, setIsExpanded] = useState(false);
+  const [currentTime, setCurrentTime] = useState('');
+  const [nickname, setNickname] = useState(''); // ✅ 1. 닉네임을 저장할 state 추가
+
+  // 컴포넌트가 처음 렌더링될 때 실행
+  useEffect(() => {
+    // 현재 날짜와 시간을 포맷에 맞게 설정
+    const now = new Date();
+    const formattedTime = `${now.getFullYear()}.${now.getMonth() + 1}.${now.getDate()} | ${now.getHours()}:${String(now.getMinutes()).padStart(2, '0')}pm`;
+    setCurrentTime(formattedTime);
+
+    // ✅ 2. localStorage에서 현재 사용자 닉네임 불러오기
+    const storedNickname = localStorage.getItem('current_user') || '방문자'; // 값이 없으면 '방문자'로 표시
+    setNickname(storedNickname);
+
+  }, []); // 빈 배열을 전달하여 한 번만 실행되도록 설정
+
+  const toggleSheet = () => {
+    setIsExpanded(!isExpanded);
+  };
+
+  return (
+    <div className={`sheet-container ${isExpanded ? 'expanded' : ''}`}>
+      <div className="sheet-header" onClick={toggleSheet}>
+        <div className="grabber"></div>
+        <div className="header-content">
+          <div className="current-time">{currentTime}</div>
+          <h2 className="sheet-title">
+            {/* ✅ 3. 하드코딩된 '소린'을 nickname state 변수로 교체 */}
+            지금 <span className="nickname">{nickname}</span>님에게 딱 맞는 장소 Top 5
+          </h2>
+        </div>
+      </div>
+      <div className="cafe-list">
+        {topCafes.map(cafe => (
+          <CafeListItem key={cafe.id} cafe={cafe} />
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/src/mocks/cafe-data.js
+++ b/src/mocks/cafe-data.js
@@ -1,0 +1,59 @@
+// src/mocks/cafe-data.js
+
+export const topCafes = [
+  {
+    id: 1,
+    name: "연희동 작가방",
+    rating: 4.8,
+    isOperating: true,
+    distance: "176m",
+    walkingTime: 5,
+    hashtags: ["#조용한", "#wifi빵빵", "#작업하기좋은"],
+    congestion: "green", // green: 여유, orange: 보통, red: 혼잡
+    imageUrl: "https://via.placeholder.com/100", // 임시 이미지
+  },
+  {
+    id: 2,
+    name: "콘하스 연희",
+    rating: 4.5,
+    isOperating: true,
+    distance: "250m",
+    walkingTime: 7,
+    hashtags: ["#분위기좋은", "#디저트맛집"],
+    congestion: "orange",
+    imageUrl: "https://via.placeholder.com/100",
+  },
+  {
+    id: 3,
+    name: "매뉴팩트커피 연희점",
+    rating: 4.9,
+    isOperating: false,
+    distance: "310m",
+    walkingTime: 8,
+    hashtags: ["#커피맛집", "#가성비"],
+    congestion: "red",
+    imageUrl: "https://via.placeholder.com/100",
+  },
+  {
+    id: 4,
+    name: "데스틴",
+    rating: 4.2,
+    isOperating: true,
+    distance: "400m",
+    walkingTime: 10,
+    hashtags: ["#조용한", "#감성카페"],
+    congestion: "green",
+    imageUrl: "https://via.placeholder.com/100",
+  },
+  {
+    id: 5,
+    name: "포멜로",
+    rating: 4.6,
+    isOperating: true,
+    distance: "450m",
+    walkingTime: 11,
+    hashtags: ["#브런치", "#디저트맛집"],
+    congestion: "orange",
+    imageUrl: "https://via.placeholder.com/100",
+  },
+];

--- a/src/pages/yunseo/MapPage.jsx
+++ b/src/pages/yunseo/MapPage.jsx
@@ -1,41 +1,50 @@
 import React, { useState } from 'react';
 import { useNavigate } from 'react-router-dom';
-import QuestArrival from '../../components/feature/quest/QuestArrival'; // 퀘스트 팝업 컴포넌트 import
+import QuestArrival from '../../components/feature/quest/QuestArrival';
+import TopCafesSheet from '../../components/feature/map/TopCafesSheet'; // 
 
 export default function MapPage() {
   const [isQuestModalOpen, setIsQuestModalOpen] = useState(false);
   const navigate = useNavigate();
 
-  // 도착햇냐->네 버튼을 눌렀을 때 실행될 함수
+  // '도착했어요' 버튼을 눌렀을 때 실행될 함수
   const handleArrivalClick = () => {
-    setIsQuestModalOpen(true); // 모달을 띄우는 상태로 변경
+    setIsQuestModalOpen(true); // 퀘스트 팝업을 띄우는 상태로 변경
   };
 
-  // 팝업에서 'No'를 눌렀을 때: 모달을 닫기만 함
+  // 퀘스트 팝업에서 'No'를 눌렀을 때
   const handleQuestDecline = () => {
     navigate('/map');
   };
 
-  // 팝업에서 'Yes'를 눌렀을 때: 퀘스트 페이지로 이동
+  // 퀘스트 팝업에서 'Yes'를 눌렀을 때
   const handleQuestAccept = () => {
-    setIsQuestModalOpen(false); // 일단 모달을 닫고
-    navigate('/quest');       // 퀘스트 전용 페이지로 이동
+    setIsQuestModalOpen(false);
+    navigate('/quest');
   };
 
   return (
-    <div className="map-container">
-      {/* --- 지도 관련 UI */ }
-      <h1>지도 페이지</h1>
-      <p>여기에 카카오 지도가 렌더링 됩니다.</p>
+    <div className="map-page-container" style={{ width: '100%', height: '100%', position: 'relative' }}>
+      {/* --- 지도 관련 UI (다른 FE 개발자 작업 영역) --- */}
+      <div style={{ width: '100%', height: '100%', backgroundColor: '#e0e0e0', display: 'flex', justifyContent: 'center', alignItems: 'center', color: '#888' }}>
+        여기에 지도가 표시됩니다. (핀 포함)
+      </div>
       
-      {/* 와이어프레임의 '도착했어요?' 버튼 */}
-      <button className="arrival-button" onClick={handleArrivalClick}>
-        매장에 도착했어요?
+      {/* '도착했어요?' 버튼 (실제로는 지도 위 특정 위치에 있을 수 있음) */}
+      <button 
+        onClick={handleArrivalClick}
+        style={{ position: 'absolute', top: '20px', left: '20px', padding: '10px', zIndex: '10' }}
+      >
+        (임시) 매장에 도착했어요?
       </button>
       {/* ------------------------------------------- */}
 
+      
+      <TopCafesSheet />
 
-      {/* isQuestModalOpen 상태가 true일 때만 퀘스트 도착 팝업을 렌더링 */}
+
+      {/* ✅ isQuestModalOpen 상태가 true일 때만 퀘스트 도착 팝업을 렌더링합니다. */}
+      {/* 이 팝업은 TopCafesSheet보다 위에 나타나야 합니다. (z-index로 제어됨) */}
       {isQuestModalOpen && (
         <QuestArrival 
           onYes={handleQuestAccept} 


### PR DESCRIPTION
### map에서 사용자의 위치정보에 따라 top5카페 하단에 띄워주는 바 생성 

-TopCafeSheet.jsx와 TopCafeSheet.css 생성 및 MapPage.jsx에서
<TopCafeSheet/>으로 라우팅

- 헤더 고정: `TopCafesSheet` 컴포넌트의 헤더가 스크롤에 따라 사라지지 않고 고정되도록 구현. (`position: sticky` 적용)
- 리스트 스크롤: 리스트 영역은 `flex`로 배치하여 스크롤이 가능하도록.

### 기타:
- 마우스로 바를 클릭하면 `TopCafesSheet`가 상단으로 올라오며, 리스트 영역만 스크롤.
- 아이폰의 하단 여백**을 고려한 스타일링을 적용했습니다.

### 테스트 방법:
1. TopCafesSheet를 눌러서 열리는지 확인합니다.
2. 현재시간과 `지금 ~ top 5` 글씨가 헤더에 고정되어 있는지 확인합
